### PR TITLE
Try avoid conflicting jquery installs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     ],
     "dependencies": {
         "angular": "1.2.6",
-        "jQuery": "1.11.0",
+        "jquery": "1.11.0",
         "hamsterjs": "1.0.4",
         "angular-mousewheel": "1.0.4"
     },


### PR DESCRIPTION
Lots of other packages install jquery in bower, but use the "jquery" label.  Calling it jQuery confuses bower and tries to make it install multiple versions.  